### PR TITLE
feat :zoomIn/Out Image 함수 추가

### DIFF
--- a/Utils/ImageProc.py
+++ b/Utils/ImageProc.py
@@ -5,4 +5,13 @@ def loadImgData(filepath):
     img_data = np.fromfile(filepath, np.uint8)
     img_data = cv2.imdecode(img_data, cv2.IMREAD_COLOR)
     img_data = cv2.cvtColor(img_data, cv2.COLOR_BGR2RGB)
-    return img_data
+    h,w,c = img_data.shape
+    return img_data, w, h, c
+
+def resizeImage(img, scaleRatio, interpolation):
+    if interpolation : itp = cv2.INTER_LINEAR
+    else : itp = cv2.INTER_AREA
+    img_data = cv2.resize(img, None, fx=scaleRatio, fy=scaleRatio,
+                     interpolation=itp)
+    h,w,c = img_data.shape
+    return img_data, w, h, c

--- a/View.py
+++ b/View.py
@@ -34,7 +34,10 @@ class HandAnnot(QMainWindow, main_form_class):
                             self.action_Save,
                             
                             self.draw_actions,
-                            self.statusBar          ]
+                            self.statusBar,
+                            self.action_Zoom_In,
+                            self.action_Zoom_Out
+                            ]
 
         self.canvas_viewmodel = Canvas(self.canvas_widget, self.model)
 

--- a/ViewModel/Canvas.py
+++ b/ViewModel/Canvas.py
@@ -28,6 +28,9 @@ class Canvas(QWidget):
         
         self.statusBar = view[5]
 
+        self.action_Zoom_In = view[6]
+        self.action_Zoom_Out = view[7]
+
         self.model = model
         self.model.setCtrlFlag(False)
         self.model.setMenuFlag(False)
@@ -43,6 +46,8 @@ class Canvas(QWidget):
         self.action_Circle.triggered.connect(self.drawCircle)
         self.action_Line.triggered.connect(self.drawLine)
         self.action_Dot.triggered.connect(self.drawDot)
+        self.action_Zoom_In.triggered.connect(self.zoomInImage)
+        self.action_Zoom_Out.triggered.connect(self.zoomOutImage)
 
         self.setMouseTracking(True)
         self.setFocusPolicy(Qt.ClickFocus)

--- a/ViewModel/Canvas.py
+++ b/ViewModel/Canvas.py
@@ -77,17 +77,29 @@ class Canvas(QWidget):
         self.model.setMenuFlag(True)
         self.menuRefresh(self.model.getMenuFlag())
 
-    # def zoomInImage(self):
-    #     resize_img = self.model.getImgData()
-    #     self.model.setScaleRatio(self.model.getScaleRatio() * 1.25)
-    #     if self.model.getScaleRatio() > 3.05 :
-    #         self.model.setScaleRatio(3.05)
-    #     if self.model.getScaleRatio() <= 3.05 :
-    #         img = resizeImage(resize_img, self.model.getScaleRatio())
-    #     print('배율 = ', self.model.getScaleRatio())
+    def zoomInImage(self):
+        img = self.model.getImgData()
+        self.model.setScaleRatio(self.model.getScaleRatio() * 1.25)
+        if self.model.getScaleRatio() > 3.05 :
+            self.model.setScaleRatio(3.05)
+        if self.model.getScaleRatio() <= 3.05 :
+            img = resizeImage(img, self.model.getScaleRatio())
+            h, w, c = img.shape
+            self.model.setImgScaled(img, w, h, c)
+            self.displayImage()
+        print('배율 = ', self.model.getScaleRatio())
 
     def zoomOutImage(self):
-        pass
+        img = self.model.getImgData()
+        self.model.setScaleRatio(self.model.getScaleRatio() * 0.8)
+        if self.model.getScaleRatio() < 0.21:
+            self.model.setScaleRatio(0.21)
+        if self.model.getScaleRatio() >= 0.21:
+            img = resizeImage(img, self.model.getScaleRatio())
+            h, w, c = img.shape
+            self.model.setImgScaled(img, w, h, c)
+            self.displayImage()
+        print('배율 = ', self.model.getScaleRatio())
     
     def drawLine(self):
         self.model.setDrawFlag('Line')


### PR DESCRIPTION
Canvas
- zoomInImage(), zoomOutImage() 함수 추가
- 메뉴 아이템 zoom in/out 클릭 시 또는 이미지에 포커스 맞춘 후 키보드, 마우스 휠 이벤트 발생 시 zoomInImage(), zoomOutImage() 호출

Utils
- resizeImage() 함수 추가
- Canvas에서 zoomInImage(), zoomOutImage() 함수에 배율을 조정한 뒤 이미지와 조정된 배율을 파라미터로 넣은 후 cv2.resize() 함수를 이용하여 resize된 이미지 데이터 반환