### PR TITLE
fix : 이미지 열기 에러 수정

### DIFF
--- a/ViewModel/Canvas.py
+++ b/ViewModel/Canvas.py
@@ -86,7 +86,7 @@ class Canvas(QWidget):
 
         self.fileName, ext = os.path.splitext(os.path.basename(self.filePath[0]))
         self.jsonPath = os.path.dirname(self.filePath[0]) + '/' + self.fileName + '.json'
-
+        self.model.initAnnotInfo()
         if ext == '.json' or os.path.isfile(self.jsonPath):
             self.model.setAnnotDict(json2Dict(self.jsonPath))
             img, w, h, c = loadImgData(self.model.getAnnotInfo()['image_path'])


### PR DESCRIPTION
Error
- 이미지를 작업 후 json으로 저장하고, 다른 이미지 파일을 열 때 기존 이미지의 작업된 주석이 표시 되어 출력됨.
- openImage를 호출할 때마다 annot의 정보를 초기화